### PR TITLE
fix: error on loading watches when one of them failed

### DIFF
--- a/pkg/collectors/price_collector_test.go
+++ b/pkg/collectors/price_collector_test.go
@@ -59,14 +59,15 @@ func TestPriceCollector_NewWatchDuringRuntime(t *testing.T) {
 	testutil.ExpectMetrics(t, c, "price_metrics_autoregister.prom", expectedPriceMetrics...)
 }
 
-func TestPriceCollector_HandlesArrayResponse(t *testing.T) {
+func TestPriceCollector_IgnoresWatchesWithoutTitle(t *testing.T) {
 	_, watchDb := testutil.NewCollectorTestDb()
-	server := testutil.CreateTestApiServer(t, watchDb, testutil.WithPricesAsArray())
+	server := testutil.CreateTestApiServer(t, watchDb)
+	emptyUuid, emptyTitleItem := testutil.NewTestItem("", 100, "CHF", 20, 15, 10)
+	watchDb[emptyUuid] = emptyTitleItem
 	defer server.Close()
 
 	client := cdio.NewTestApiClient(server.URL())
 	c := NewPriceCollector(client)
 
-	testutil.ExpectMetricCount(t, c, 2, expectedPriceMetrics...)
 	testutil.ExpectMetrics(t, c, "price_metrics.prom", expectedPriceMetrics...)
 }

--- a/pkg/data/api.go
+++ b/pkg/data/api.go
@@ -7,17 +7,28 @@ import (
 	"net/url"
 )
 
+type StringBoolean bool
+
+func (sb *StringBoolean) UnmarshalJSON(data []byte) error {
+	if string(data) == "false" {
+		*sb = false
+	} else {
+		*sb = true
+	}
+	return nil
+}
+
 type WatchItem struct {
-	LastChanged            int64      `json:"last_changed"`
-	LastChecked            int64      `json:"last_checked"`
-	LastError              bool       `json:"last_error"`
-	Title                  string     `json:"title"`
-	Url                    string     `json:"url"`
-	CheckCount             int        `json:"check_count,omitempty"`
-	FetchTime              float64    `json:"fetch_time,omitempty"`
-	NotificationAlertCount int        `json:"notification_alert_count,omitempty"`
-	LastCheckStatus        int        `json:"last_check_status,omitempty"`
-	PriceData              *PriceData `json:"price,omitempty"`
+	LastChanged            int64         `json:"last_changed"`
+	LastChecked            int64         `json:"last_checked"`
+	LastError              StringBoolean `json:"last_error"`
+	Title                  string        `json:"title"`
+	Url                    string        `json:"url"`
+	CheckCount             int           `json:"check_count,omitempty"`
+	FetchTime              float64       `json:"fetch_time,omitempty"`
+	NotificationAlertCount int           `json:"notification_alert_count,omitempty"`
+	LastCheckStatus        int           `json:"last_check_status,omitempty"`
+	PriceData              *PriceData    `json:"price,omitempty"`
 }
 
 type PriceData struct {

--- a/pkg/data/api.go
+++ b/pkg/data/api.go
@@ -46,10 +46,13 @@ type SystemInfo struct {
 }
 
 func (w *WatchItem) GetMetrics() ([]string, error) {
-	url, err := url.Parse(w.Url)
+	url, err := url.ParseRequestURI(w.Url)
 	if err != nil {
 		return nil, err
+	} else if url.Host == "" {
+		return nil, fmt.Errorf("host is empty")
 	}
+
 	if w.Title == "" {
 		return nil, fmt.Errorf("title is empty")
 	}

--- a/pkg/data/api_test.go
+++ b/pkg/data/api_test.go
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2024 Stefan Schärmeli <schaermu@pm.me>
+// SPDX-License-Identifier: MIT
+package data
+
+import "testing"
+
+func TestStringBoolean_ProperlyUnmarshals(t *testing.T) {
+	sb := StringBoolean(false)
+	err := sb.UnmarshalJSON([]byte("false"))
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if sb != false {
+		t.Errorf("Expected false, got %v", sb)
+	}
+
+	sb = StringBoolean(true)
+	err = sb.UnmarshalJSON([]byte("true"))
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if sb != true {
+		t.Errorf("Expected true, got %v", sb)
+	}
+}
+
+func TestStringBoolean_UnmarshalsAnyStringToTrue(t *testing.T) {
+	sb := StringBoolean(true)
+	err := sb.UnmarshalJSON([]byte("yehyehyeh foobar"))
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if sb != true {
+		t.Errorf("Expected true, got %v", sb)
+	}
+}
+
+func TestWatchItem_GetMetrics(t *testing.T) {
+	w := WatchItem{
+		Title: "Test",
+		Url:   "https://example.com",
+	}
+	metrics, err := w.GetMetrics()
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if len(metrics) != 2 {
+		t.Errorf("Expected 2 metrics, got %v", len(metrics))
+	}
+	if metrics[0] != "Test" {
+		t.Errorf("Expected Test, got %v", metrics[0])
+	}
+	if metrics[1] != "example.com" {
+		t.Errorf("Expected example.com, got %v", metrics[1])
+	}
+}
+
+func TestWatchItem_GetMetrics_EmptyTitle(t *testing.T) {
+	w := WatchItem{
+		Url: "https://example.com",
+	}
+	_, err := w.GetMetrics()
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+}

--- a/pkg/data/api_test.go
+++ b/pkg/data/api_test.go
@@ -64,3 +64,25 @@ func TestWatchItem_GetMetrics_EmptyTitle(t *testing.T) {
 		t.Errorf("Expected error, got nil")
 	}
 }
+
+func TestWatchItem_GetMetrics_InvalidUri(t *testing.T) {
+	w := WatchItem{
+		Title: "Test",
+		Url:   "foo-bar-is-not-a-uri",
+	}
+	_, err := w.GetMetrics()
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+}
+
+func TestWatchItem_GetMetrics_EmptyHost(t *testing.T) {
+	w := WatchItem{
+		Title: "Test",
+		Url:   "http://",
+	}
+	_, err := w.GetMetrics()
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+}


### PR DESCRIPTION
The API of CDIO returns either Boolean `false` or a string containing some error on the `last_error` field when fetching watches.

This PR implements a custom type `StringBoolean` which unmarshals the exact string `false` as Boolean false and everything else as `true`.