### PR TITLE
cicd: upgrade setup-go to v5 and checkout to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,13 +12,13 @@ jobs:
 
     steps:
     - name: Download Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: 1.22
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Get dependencies
       run: go get -v -t -d ./...


### PR DESCRIPTION
Upgrades actions in test workflow to get rid of deprecation warnings